### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,7 @@
 name: Publish to NuGet
+permissions:
+  contents: read
+  packages: write
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/Spire-Recovery-Solutions/Paywire.NET/security/code-scanning/1](https://github.com/Spire-Recovery-Solutions/Paywire.NET/security/code-scanning/1)

To fix the issue, add a `permissions` block at the root of the workflow file to explicitly define the permissions required. Based on the operations in the workflow:
- `contents: read` is sufficient for most steps, such as checking out the code and running tests.
- `packages: write` is required for the "Push to NuGet" step to upload the package.

The `permissions` block will be added at the root level to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
